### PR TITLE
added option unwrap (inspired by Rust)

### DIFF
--- a/src/DataTypes/Option/Option.On.cs
+++ b/src/DataTypes/Option/Option.On.cs
@@ -22,5 +22,11 @@ namespace TinyFp
         [Pure]
         public A OrElse(A val)
             => _isSome ? _value : val;
+
+        [Pure]
+        public A Unwrap() 
+            => _isSome
+                ? _value
+                : throw new InvalidOperationException();
     }
 }

--- a/test/DataTypes/Option/OptionTests.cs
+++ b/test/DataTypes/Option/OptionTests.cs
@@ -92,6 +92,22 @@ namespace TinyFpTest.DataTypes
                 .Should().BeTrue();
 
         [Test]
+        public void UnWrap_WhenIsSome_ShouldReturnValue()
+            => Option<string>
+                .Some("not-empty")
+                .Unwrap()
+                .Should()
+                .Be("not-empty");
+
+        [Test]
+        public void UnWrap_WhenIsNone_ShouldThrow()
+            => Option<string>
+                .None()
+                .Invoking(_ => _.Unwrap())
+                .Should()
+                .Throw<InvalidOperationException>();
+
+        [Test]
         public void Map_MapNoneInOutput()
             => Option<string>
                     .None()


### PR DESCRIPTION
This is a proposal to introduce the `unwrap` method on Options, similar to the one available in Rust (see https://doc.rust-lang.org/rust-by-example/error/option_unwrap.html)

One of the possible advantages is when you want to pass from `IEnumerable<Option<T>>` to `IEnumerable<T>` filtering out the `None` items.

Currently the only way to do it is (`new T()` is a shortcut):

```
enumerable
  .Where(_ => _.IsSome)
  .Select(_ => _.Match(x => x, () => new T()))
```

Anyway the OnLeft part of the match will never be called because of the previous `Where` instruction