### PR TITLE
Proposal for introducing UnwrapRight and UnwrapLeft for Either

### DIFF
--- a/src/DataTypes/Either/Either.cs
+++ b/src/DataTypes/Either/Either.cs
@@ -62,5 +62,13 @@ namespace TinyFp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !(Either<L, R> value)
             => value.IsLeft;
+
+        [Pure]
+        public R UnwrapRight()
+            => _isRight ? _right : throw new InvalidOperationException();
+
+        [Pure]
+        public L UnwrapLeft()
+            => !_isRight ? _left : throw new InvalidOperationException();
     }
 }

--- a/test/DataTypes/Either/EitherTests.cs
+++ b/test/DataTypes/Either/EitherTests.cs
@@ -346,6 +346,38 @@ namespace TinyFpTest.DataTypes
         }
 
         [Test]
+        public void WhenRight_UnwrapRightReturnsValue() 
+            => Either<string, int>
+                .Right(12)
+                .UnwrapRight()
+                .Should()
+                .Be(12);
+
+        [Test]
+        public void WhenLeft_UnwrapLeftReturnsValue()
+            => Either<string, int>
+                .Left("something")
+                .UnwrapLeft()
+                .Should()
+                .Be("something");
+
+        [Test]
+        public void WhenRight_UnwrapLeftShouldThrow()
+            => Either<string, int>
+                .Right(12)
+                .Invoking(_ => _.UnwrapLeft())
+                .Should()
+                .Throw<InvalidOperationException>();
+
+        [Test]
+        public void WhenLeft_UnwrapRightShouldThrow()
+            => Either<string, int>
+                .Left("something")
+                .Invoking(_ => _.UnwrapRight())
+                .Should()
+                .Throw<InvalidOperationException>();
+
+        [Test]
         public void OperatorTrue_WhenRight_IsTrue()
         {
             if (Either<string, int>.Right(42))

--- a/tiny-fp.sln.DotSettings.user
+++ b/tiny-fp.sln.DotSettings.user
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=10e8e089_002D9110_002D475a_002Db183_002D3d1795c597d8/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="UnWrap_WhenIsSOme_ShouldReturnValue" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::F90BE76F-5095-4A4D-BF7A-DCFDD0FFF3C6::net6.0::TinyFpTest.DataTypes.EitherTests.WhenRight_UnwrapLeftShouldThrow&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/tiny-fp.sln.DotSettings.user
+++ b/tiny-fp.sln.DotSettings.user
@@ -1,6 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=10e8e089_002D9110_002D475a_002Db183_002D3d1795c597d8/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="UnWrap_WhenIsSOme_ShouldReturnValue" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::F90BE76F-5095-4A4D-BF7A-DCFDD0FFF3C6::net6.0::TinyFpTest.DataTypes.EitherTests.WhenRight_UnwrapLeftShouldThrow&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Similar to `Unwrap` for `Option`, `UnwrapRight` and `UnwrapLeft` give access to the internal values if the monads is in the correct status, otherwise they throw an `InvalidOperationException`